### PR TITLE
Improve URL verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "now": "^10.2.2",
     "puppeteer": "^1.2.0",
     "random-uuid": "*",
-    "universal-analytics": "^0.4.16"
+    "universal-analytics": "^0.4.16",
+    "whatwg-url": "^6.4.0"
   },
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
The previous URL checks are trivial to bypass (e.g. by changing the casing).

For any kind of URL validation, avoid string comparisons. It’s safer to use `new URL(string)` and rely on the URL API’s functionality. This guarantees you’re dealing with a normalized URL object.