### PR TITLE
Use Node’s built-in `url` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "now": "^10.2.2",
     "puppeteer": "^1.2.0",
     "random-uuid": "*",
-    "universal-analytics": "^0.4.16",
-    "whatwg-url": "^6.4.0"
+    "universal-analytics": "^0.4.16"
   },
   "engines": {
     "node": ">=8"

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ const fs = require('fs');
 const util = require('util');
 const marked = require('marked');
 const ua = require('universal-analytics');
-const {URL} = require('whatwg-url');
+const {URL} = require('url');
 const gsearch = require('./helpers/gsearch.js');
 
 const PORT = process.env.PORT || 8084;


### PR DESCRIPTION
Since this project supports Node.js v8+ only, we don’t need the `whatwg-url` dependency.